### PR TITLE
Relax upper bound on base16-bytestring

### DIFF
--- a/implicit-hie-cradle.cabal
+++ b/implicit-hie-cradle.cabal
@@ -34,7 +34,7 @@ library
   hs-source-dirs:   src
   build-depends:
       base                  >=4.8     && <5
-    , base16-bytestring     >=0.1.1   && <0.2
+    , base16-bytestring     >=0.1.1   && <1.1
     , bytestring            >=0.10.8  && <0.11
     , containers            >=0.5.10  && <0.7
     , directory             >=1.3.0   && <1.4


### PR DESCRIPTION
This works for me when built with base16-bytestring 1.0.1.0 inside hls.