### PR TITLE
Allow transformers-0.6

### DIFF
--- a/implicit-hie-cradle.cabal
+++ b/implicit-hie-cradle.cabal
@@ -32,7 +32,7 @@ library
     , hie-bios              >=0.7.0
     , implicit-hie          >=0.1.2.6 && <1
     , process               >=1.6.1   && <1.7
-    , transformers          >=0.5.2   && <0.6
+    , transformers          >=0.5.2   && <0.7
 
   default-language: Haskell2010
   ghc-options:


### PR DESCRIPTION
As a Hackage trustee I made a matching revision:
https://hackage.haskell.org/package/implicit-hie-cradle-0.5.0.1/revisions/